### PR TITLE
APOLLO-15047: Not hardcode random version in script demo/build.sh

### DIFF
--- a/demo/build.sh
+++ b/demo/build.sh
@@ -25,5 +25,5 @@ if [ -z "$TARGET_PATH" ] || [ ! -d "$TARGET_PATH" ]; then
     exit 1
 fi
 
-cp build/plugins/random-connector-0.1.1.zip "$TARGET_PATH"
+cp build/plugins/random-connector.zip "$TARGET_PATH"
 

--- a/java-sdk/connectors/build.gradle
+++ b/java-sdk/connectors/build.gradle
@@ -28,7 +28,7 @@ subprojects {
   }
 
   task plugin(type: Jar) {
-    baseName = "${project.name}"
+    archiveName = "${project.name}" + ".zip"
     manifest {
       attributes 'Plugin-Class': "${pluginClass}",
           'Plugin-Type': "connector",


### PR DESCRIPTION
# Tl;dr
- Not hardcode random version in script demo/build.sh
# Details
- Rename zip name in  `java-sdk/connectors/build.gradle`
- Not hardcode random version in script demo/build.sh

# How to verify
- From local repository connectors-sdk-resources, run the build script i.e. :
```
connectors-sdk-resources$ ./demo/build.sh master <my path to fusion> <my fusion version> <my path targeth>
```
- the random connector generated  has not the random version `random-connector.zip`