### PR TITLE
A few convenience tasks: connect and deploy

### DIFF
--- a/java-sdk/connectors/build.gradle
+++ b/java-sdk/connectors/build.gradle
@@ -28,7 +28,7 @@ subprojects {
   }
 
   task plugin(type: Jar) {
-    archiveName = "${project.name}" + ".zip"
+    archiveName = "${project.name}-${version}" + ".zip"
     manifest {
       attributes 'Plugin-Class': "${pluginClass}",
           'Plugin-Type': "connector",
@@ -47,6 +47,37 @@ subprojects {
   task assemblePlugin(type: Copy) {
     from plugin
     into pluginsDir
+  }
+
+  task deploy(type: Exec, dependsOn: ["assemblePlugin"]) {
+    commandLine "curl", "-X", "PUT", "-H", "content-type:application/zip",
+            "http://${fusionApiTarget}/api/v1/blobs/lucidworks.sdk.${project.name}-${version}.zip?resourceType=plugin:connector",
+            "--data-binary",
+            "@${pluginsDir}/${plugin.outputs.files.singleFile.getName()}"
+    doLast {
+      logger.info("Curl result: ${standardOutput.toString().trim()}")
+    }
+  }
+
+  task connect(type: Exec, dependsOn: ["assemblePlugin"]) {
+    def clientJar = "${fusionHome}/apps/connectors/connectors-rpc/client/connector-plugin-client-${fusionVersion}-uberjar.jar"
+    def argsList = []
+    argsList << "java"
+    argsList << "-Dcom.lucidworks.fusion.plugin.hosts=${fusionRpcTarget}"
+    argsList << "-Dcom.lucidworks.fusion.plugin.stop.port=${stopPort}"
+    if (project.hasProperty("debug")) {
+      argsList << "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5010"
+    }
+    argsList << "-jar"
+    argsList << clientJar
+    argsList << "${project.buildDir}/libs/${project.name}-${version}.zip"
+
+    commandLine argsList
+
+    doFirst {
+      println "   -- Using client-jar ${clientJar}"
+      println "   -- Connecting plugin ${project.buildDir}/libs/${project.name}-${version}.zip to ${fusionRpcTarget}"
+    }
   }
 }
 

--- a/java-sdk/connectors/build.gradle
+++ b/java-sdk/connectors/build.gradle
@@ -70,7 +70,7 @@ subprojects {
     }
     argsList << "-jar"
     argsList << clientJar
-    argsList << "${project.buildDir}/libs/${project.name}-${version}.zip"
+    argsList << "${project.buildDir}/libs/${project.name}.zip"
 
     commandLine argsList
 

--- a/java-sdk/connectors/build.gradle
+++ b/java-sdk/connectors/build.gradle
@@ -51,7 +51,7 @@ subprojects {
 
   task deploy(type: Exec, dependsOn: ["assemblePlugin"]) {
     commandLine "curl", "-X", "PUT", "-H", "content-type:application/zip",
-            "http://${fusionApiTarget}/api/v1/blobs/lucidworks.sdk.${project.name}-${version}.zip?resourceType=plugin:connector",
+            "http://${fusionApiTarget}/api/v1/blobs/lucidworks.sdk.${project.name}.zip?resourceType=plugin:connector",
             "--data-binary",
             "@${pluginsDir}/${plugin.outputs.files.singleFile.getName()}"
     doLast {

--- a/java-sdk/connectors/build.gradle
+++ b/java-sdk/connectors/build.gradle
@@ -76,7 +76,7 @@ subprojects {
 
     doFirst {
       println "   -- Using client-jar ${clientJar}"
-      println "   -- Connecting plugin ${project.buildDir}/libs/${project.name}-${version}.zip to ${fusionRpcTarget}"
+      println "   -- Connecting plugin ${project.buildDir}/libs/${project.name}.zip to ${fusionRpcTarget}"
     }
   }
 }

--- a/java-sdk/connectors/build.gradle
+++ b/java-sdk/connectors/build.gradle
@@ -28,7 +28,7 @@ subprojects {
   }
 
   task plugin(type: Jar) {
-    archiveName = "${project.name}-${version}" + ".zip"
+    archiveName = "${project.name}" + ".zip"
     manifest {
       attributes 'Plugin-Class': "${pluginClass}",
           'Plugin-Type': "connector",

--- a/java-sdk/connectors/gradle.properties
+++ b/java-sdk/connectors/gradle.properties
@@ -10,6 +10,6 @@ fusionHome=/path/to/fusion/4.1.0
 
 # Fusion target version, it should match the Fusion version from the fusion homme
 stopPort=55051
-fusionVersion=4.2.0-SNAPSHOT
+fusionVersion=4.1.0
 fusionApiTarget=localhost:8765
 fusionRpcTarget=localhost:8771

--- a/java-sdk/connectors/gradle.properties
+++ b/java-sdk/connectors/gradle.properties
@@ -6,7 +6,7 @@ version=0.1.1
 # change the fusion home
 # The folder where fusion was downloaded ie: /opt/fusion/4.0.1
 # Note: it needs to include the path full path until the Fusion version
-fusionHome=/var/fusion
+fusionHome=/path/to/fusion/4.1.0
 
 # Fusion target version, it should match the Fusion version from the fusion homme
 stopPort=55051

--- a/java-sdk/connectors/gradle.properties
+++ b/java-sdk/connectors/gradle.properties
@@ -6,7 +6,10 @@ version=0.1.1
 # change the fusion home
 # The folder where fusion was downloaded ie: /opt/fusion/4.0.1
 # Note: it needs to include the path full path until the Fusion version
-fusionHome=/path/to/fusion/4.1.0
+fusionHome=/var/fusion
 
 # Fusion target version, it should match the Fusion version from the fusion homme
-fusionVersion=4.1.0
+stopPort=55051
+fusionVersion=4.2.0-SNAPSHOT
+fusionApiTarget=localhost:8765
+fusionRpcTarget=localhost:8771

--- a/java-sdk/connectors/random-connector/gradle.properties
+++ b/java-sdk/connectors/random-connector/gradle.properties
@@ -2,3 +2,4 @@
 pluginId=lucidworks.random.content
 pluginProvider=Lucidworks
 pluginClass=com.lucidworks.fusion.connector.plugin.RandomContentPlugin
+minorVersion=1.0.0


### PR DESCRIPTION
Added a few tasks to help the development process:

`connect` - builds the plugin and does a remote connect to a connectors-rpc service
`deploy` - builds the plugin and uploads the zip to a Blobs api