### PR TITLE
APOLLO-17196: add sdk version as parameter

### DIFF
--- a/java-sdk/connectors/build.gradle
+++ b/java-sdk/connectors/build.gradle
@@ -35,7 +35,7 @@ subprojects {
           'Plugin-Id': "${pluginId}",
           'Plugin-Version': "${fusionVersion}",
           'Plugin-Provider': "${pluginProvider}",
-          'Plugin-Connectors-SDK-Version': '1.0.1'
+          'Plugin-Connectors-SDK-Version': "${connectorsSDKVersion}"
     }
     into('lib') {
       from configurations.compile - configurations.provided

--- a/java-sdk/connectors/gradle.properties
+++ b/java-sdk/connectors/gradle.properties
@@ -2,6 +2,8 @@
 group=com.lucidworks.fusion
 version=0.1.1
 
+connectorsSDKVersion=1.1.0
+
 # Important!
 # change the fusion home
 # The folder where fusion was downloaded ie: /opt/fusion/4.0.1


### PR DESCRIPTION
Easily build with the sdk version as a parameter

```
./gradlew assemblePlugin -PconnectorsSDKVersion=SDK_VERSION 
```