### PR TITLE
APOLLO-19370: Remove deprecated warnings from build

### DIFF
--- a/java-sdk/connectors/imap-connector/src/main/java/com/lucidworks/fusion/connector/plugin/ImapFetcher.java
+++ b/java-sdk/connectors/imap-connector/src/main/java/com/lucidworks/fusion/connector/plugin/ImapFetcher.java
@@ -66,7 +66,6 @@ public class ImapFetcher implements ContentFetcher {
 
         fetchContext.newDocument(fetchContext.getFetchInput().getId())
           .withFields(data)
-          .withMetadata(null)
           .emit();
       }
 

--- a/java-sdk/connectors/imap-connector/src/main/java/com/lucidworks/fusion/connector/plugin/ImapFetcher.java
+++ b/java-sdk/connectors/imap-connector/src/main/java/com/lucidworks/fusion/connector/plugin/ImapFetcher.java
@@ -64,13 +64,18 @@ public class ImapFetcher implements ContentFetcher {
           };
         }
 
-        fetchContext.emitDocument(data);
+        fetchContext.newDocument(fetchContext.getFetchInput().getId())
+          .withFields(data)
+          .withMetadata(null)
+          .emit();
       }
 
     } catch (MailException e) {
       String message = "Failed to parse message.";
       logger.error(message, e);
-      fetchContext.emitError(message);
+      fetchContext.newError(fetchContext.getFetchInput().getId())
+        .withError(message)
+        .emit();
     }
 
     return fetchContext.newResult();

--- a/java-sdk/connectors/random-connector/src/main/java/com/lucidworks/fusion/connector/plugin/RandomContentFetcher.java
+++ b/java-sdk/connectors/random-connector/src/main/java/com/lucidworks/fusion/connector/plugin/RandomContentFetcher.java
@@ -71,7 +71,7 @@ public class RandomContentFetcher implements ContentFetcher {
     int numSentences = getRandomNumberInRange(10, 255);
     String txt = generator.makeText(numSentences);
 
-    Map<String, Object> fields = new HashMap();
+    Map<String, Object> fields = new HashMap<>();
     fields.put("number_i", num);
     fields.put("timestamp_l", Instant.now().toEpochMilli());
     fields.put("headline_s", headline);

--- a/java-sdk/connectors/security-filtering-connector/src/main/java/com/lucidworks/fusion/connector/plugin/config/SecurityFilteringConfig.java
+++ b/java-sdk/connectors/security-filtering-connector/src/main/java/com/lucidworks/fusion/connector/plugin/config/SecurityFilteringConfig.java
@@ -1,7 +1,7 @@
 package com.lucidworks.fusion.connector.plugin.config;
 
 import com.lucidworks.fusion.connector.plugin.RandomContentConfig;
-import com.lucidworks.fusion.connector.plugin.api.config.SecurityTrimmingProperties;
+import com.lucidworks.fusion.connector.plugin.api.config.SecurityTrimmingConfig;
 import com.lucidworks.fusion.schema.SchemaAnnotations.NumberSchema;
 import com.lucidworks.fusion.schema.SchemaAnnotations.Property;
 import com.lucidworks.fusion.schema.SchemaAnnotations.RootSchema;
@@ -21,7 +21,7 @@ public interface SecurityFilteringConfig extends RandomContentConfig {
   )
   Properties properties();
   
-  interface Properties extends RandomContentConfig.Properties, SecurityTrimmingProperties {
+  interface Properties extends RandomContentConfig.Properties, SecurityTrimmingConfig {
     @Property(
         title = "Nested groups",
         description = "Number of nested groups"


### PR DESCRIPTION
On build, there were warnings about using deprecated methods and classes for the security-filtering-connector and imap-connector.

- Updated security-filtering-connector's config class to extend recommended class given by the deprecation notice in the SDK.
- Updated imap-connector to use newDocument and newError methods instead of the deprecated emitDocument and emitError methods.