### PR TITLE
APOLLO-23311: removed deprecated withFields and withMetadata

### DIFF
--- a/java-sdk/connectors/gradle.properties
+++ b/java-sdk/connectors/gradle.properties
@@ -2,7 +2,7 @@
 group=com.lucidworks.fusion
 version=1.0.0
 
-connectorsSDKVersion=1.4.0
+connectorsSDKVersion=2.0.0
 
 # Deploy tasks
 userPass=admin:a-very-secret-password

--- a/java-sdk/connectors/imap-connector/build.gradle
+++ b/java-sdk/connectors/imap-connector/build.gradle
@@ -4,4 +4,5 @@ dependencies {
   implementation 'com.sun.mail:javax.mail:1.6.1'
 
   testCompile group: 'org.mockito', name: 'mockito-core', version: '2.23.4'
+  testCompile "com.lucidworks-schema:schema:${connectorsSDKVersion}"
 }

--- a/java-sdk/connectors/imap-connector/src/main/java/com/lucidworks/connectors/plugins/imap/ImapFetcher.java
+++ b/java-sdk/connectors/imap-connector/src/main/java/com/lucidworks/connectors/plugins/imap/ImapFetcher.java
@@ -65,7 +65,7 @@ public class ImapFetcher implements ContentFetcher {
         }
 
         fetchContext.newDocument(fetchContext.getFetchInput().getId())
-          .withFields(data)
+          .fields(f -> f.merge(data))
           .emit();
       }
 

--- a/java-sdk/connectors/random-connector/src/main/java/com/lucidworks/connectors/plugins/random/fetcher/RandomContentFetcher.java
+++ b/java-sdk/connectors/random-connector/src/main/java/com/lucidworks/connectors/plugins/random/fetcher/RandomContentFetcher.java
@@ -48,7 +48,7 @@ public class RandomContentFetcher implements ContentFetcher {
           logger.info("Emitting candidate -> number {}", i);
           Map<String, Object> data = Collections.singletonMap("number", i);
           preFetchContext.newCandidate(String.valueOf(i))
-              .withMetadata(data)
+              .metadata(m -> m.merge(data))
               .emit();
         });
     // Simulating an error item here... because we're emitting an item without a "number",
@@ -77,7 +77,7 @@ public class RandomContentFetcher implements ContentFetcher {
       Map<String, Object> fields = getFields(num);
 
       fetchContext.newDocument()
-          .withFields(fields)
+          .fields(f -> f.merge(fields))
           .emit();
     } catch (NullPointerException npe) {
       if (ERROR_ID.equals(input.getId())) {

--- a/java-sdk/connectors/security-filtering-connector/src/main/java/com/lucidworks/connectors/plugins/security/fetcher/SecurityFilteringAccessControlFetcher.java
+++ b/java-sdk/connectors/security-filtering-connector/src/main/java/com/lucidworks/connectors/plugins/security/fetcher/SecurityFilteringAccessControlFetcher.java
@@ -97,6 +97,6 @@ public class SecurityFilteringAccessControlFetcher implements AccessControlFetch
     if (!Strings.isNullOrEmpty(parentId)) {
       metadata.put(SecurityFilteringConstants.PARENTS, parentId);
     }
-    context.newCandidate(id).withMetadata(metadata).emit();
+    context.newCandidate(id).metadata(m -> m.merge(metadata)).emit();
   }
 }

--- a/java-sdk/connectors/security-filtering-connector/src/main/java/com/lucidworks/connectors/plugins/security/fetcher/SecurityFilteringContentFetcher.java
+++ b/java-sdk/connectors/security-filtering-connector/src/main/java/com/lucidworks/connectors/plugins/security/fetcher/SecurityFilteringContentFetcher.java
@@ -61,7 +61,7 @@ public class SecurityFilteringContentFetcher implements ContentFetcher {
     Optional<SecurityDocument> document = documentGenerator.generate(input.getId(), input.getMetadata());
     document.ifPresent(securityDocument -> {
       fetchContext.newDocument()
-          .withFields(securityDocument.getFields())
+          .fields(f -> f.merge(securityDocument.getFields()))
           .withACLs(securityDocument.getPermissions()
               .stream()
               .map(Permission::getId)
@@ -72,7 +72,10 @@ public class SecurityFilteringContentFetcher implements ContentFetcher {
         Map<String, Object> metadata = new HashMap<>();
         metadata.put(SecurityFilteringConstants.ASSIGNED, permission.getAssigned());
         metadata.put(SecurityFilteringConstants.TYPE, SecurityFilteringConstants.PERMISSION_TYPE);
-        fetchContext.newCandidate(permission.getId()).withTargetPhase(ACCESS_CONTROL).withMetadata(metadata).emit();
+        fetchContext.newCandidate(permission.getId())
+                .withTargetPhase(ACCESS_CONTROL)
+                .metadata(m -> m.merge(metadata))
+                .emit();
       }
     });
     return fetchContext.newResult();
@@ -82,6 +85,6 @@ public class SecurityFilteringContentFetcher implements ContentFetcher {
     Map<String, Object> metadata = new HashMap<>();
     metadata.put(SecurityFilteringConstants.TYPE, documentType.name());
     metadata.put("index", index);
-    preFetchContext.newCandidate(String.format("item-%d", index)).withMetadata(metadata).emit();
+    preFetchContext.newCandidate(String.format("item-%d", index)).metadata(m-> m.merge(metadata)).emit();
   }
 }


### PR DESCRIPTION
Removed the deprecated withFields and withMetadata methods from the example connectors.