### PR TITLE
APOLLO-27117-links to tree

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -31,16 +31,16 @@ upload the exact same artifact (a zip file) into Fusion, so Fusion can host it f
 
 |====================================================
 | Fusion release | SDK version
-| 5.2.1 | link:https://github.com/lucidworks/connectors-sdk-resources/releases/tag/v2.0.3[2.0.3]
-| 5.2.0 | link:https://github.com/lucidworks/connectors-sdk-resources/releases/tag/v2.0.2[2.0.2]
-| 5.1.2 - 5.1.4 | link:https://github.com/lucidworks/connectors-sdk-resources/releases/tag/v2.0.1[2.0.1]
-| 5.1.0 - 5.1.1 | link:https://github.com/lucidworks/connectors-sdk-resources/releases/tag/v2.0.0[2.0.0]
+| 5.2.1 | link:https://github.com/lucidworks/connectors-sdk-resources/tree/v2.0.3[2.0.3]
+| 5.2.0 | link:https://github.com/lucidworks/connectors-sdk-resources/tree/v2.0.2[2.0.2]
+| 5.1.2 - 5.1.4 | link:https://github.com/lucidworks/connectors-sdk-resources/tree/v2.0.1[2.0.1]
+| 5.1.0 - 5.1.1 | link:https://github.com/lucidworks/connectors-sdk-resources/tree/v2.0.0[2.0.0]
 | 5.0.2 | 2.0.0-pre-release
-| 4.2.6 | link:https://github.com/lucidworks/connectors-sdk-resources/releases/tag/v1.5.0[1.5.0]
-| 4.2.4 - 4.2.5 | link:https://github.com/lucidworks/connectors-sdk-resources/releases/tag/v1.4.0[1.4.0]
-| 4.2.2 - 4.2.3 | link:https://github.com/lucidworks/connectors-sdk-resources/releases/tag/v1.3.0[1.3.0]
-| 4.2.1 | link:https://github.com/lucidworks/connectors-sdk-resources/releases/tag/v1.2.0[1.2.0]
-| 4.2.0 | link:https://github.com/lucidworks/connectors-sdk-resources/releases/tag/v1.1.0[1.1.0]
+| 4.2.6 | link:https://github.com/lucidworks/connectors-sdk-resources/tree/v1.5.0[1.5.0]
+| 4.2.4 - 4.2.5 | link:https://github.com/lucidworks/connectors-sdk-resources/tree/v1.4.0[1.4.0]
+| 4.2.2 - 4.2.3 | link:https://github.com/lucidworks/connectors-sdk-resources/tree/v1.3.0[1.3.0]
+| 4.2.1 | link:https://github.com/lucidworks/connectors-sdk-resources/tree/v1.2.0[1.2.0]
+| 4.2.0 | link:https://github.com/lucidworks/connectors-sdk-resources/tree/v1.1.0[1.1.0]
 |====================================================
 
 == Java SDK

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -102,4 +102,4 @@ For example, when a document replace is immediately followed by a delete-by-quer
 | fetchInput_id_s  | FetchInput Id.  | /app
 |====================================================
 :
-Copyright 2019 https://lucidworks.com[Lucidworks^]
+Copyright 2020 https://lucidworks.com[Lucidworks^]


### PR DESCRIPTION
APOLLO-27117: links to tree

Version Matrix:
The tag link doesn't provide good information - it just shows the tag.
https://github.com/lucidworks/connectors-sdk-resources/releases/tag/v2.0.3 

The tree view - goes to the 'branch/tag' source code
https://github.com/lucidworks/connectors-sdk-resources/tree/v2.0.3