### PR TITLE
APOLLO-29034: connect task

### DIFF
--- a/java-sdk/connectors/README.md
+++ b/java-sdk/connectors/README.md
@@ -38,7 +38,7 @@ To target a specific SDK version, checkout the appropriate git tag version befor
 
 From `java-sdk/connectors/simple-connector`, execute the deploy task to automatically deploy the connector to a Fusion, the url can be configurated as show. By default points to localhost.
 ```bash
-./gradlew deploy -PrestService=http://127.0.0.1:6764/connectors
+./gradlew deploy -PrestService=http://127.0.0.1:6764/connectors -PuserPass=<user>:<password>
 ```
 
 While developing the plugin, you will need a way to deploy your changes quick and easy to Fusion.
@@ -63,6 +63,35 @@ $fusion_password = "password"
 $base64AuthInfo = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(("{0}:{1}" -f $fusion_username,$fusion_password)))
 Invoke-RestMethod -Headers @{Authorization=("Basic {0}" -f $base64AuthInfo)} -Method PUT -ContentType "application/zip" "${FUSION_PROXY_URL}" -InFile "${PLUGIN_ZIP_PATH}"
 ```
+
+## Connect to Fusion Remotely
+
+Before trying to run plugins remotely, please go to [lucidworks](https://doc.lucidworks.com) to check how to configure fusion to run plugins remotely.
+
+A configuration file `config.yaml` holding the cluster information is needed in order to connect remotely to a fusion cluster.
+
+```bash
+pulsar:
+  service-url: <Pulsar Service URL>
+  admin-url: <Pulsar Admin URL>
+  tenant-name: <Pulsar Tenant Name (kube namespace)>
+  authenticationEnabled: <Pulsar authentication enabled flag>
+  tlsEnabled: <TLS enabled flag>
+proxy:
+  user: <Fusion proxy user>
+  password: <Fusion proxy password>
+  url: <Fusion proxy url>
+```
+NOTE: The `plugin.path` is not needed since the gradle task injects the plugin zip.
+
+The steps to use the `connect` tasks are the following:
+1. Create a `config.yaml` with your cluster information.
+2. Verify that the fusionVersion is correct on the gradle.properties file.
+3. Execute the `connect` task providing the plugin name and, the path to the configuration file.
+```bash
+./gradlew -p simple-connector connect -PconfigYamlPath=/path/to/config.yaml
+```
+4. After connecting to the cluster you should be able to see the plugin in Fusion's UI.
 
 ## Java version
 

--- a/java-sdk/connectors/README.md
+++ b/java-sdk/connectors/README.md
@@ -66,7 +66,7 @@ Invoke-RestMethod -Headers @{Authorization=("Basic {0}" -f $base64AuthInfo)} -Me
 
 ## Connect to Fusion Remotely
 
-Before trying to run plugins remotely, please go to [lucidworks](https://doc.lucidworks.com) to check how to configure fusion to run plugins remotely.
+Before trying to run plugins remotely, please go to [remote-connector documentation](https://doc.lucidworks.com/how-to/8869/use-a-remote-connector-with-pulsar-proxy) to check how to configure fusion to run plugins remotely.
 
 A configuration file `config.yaml` holding the cluster information is needed in order to connect remotely to a fusion cluster.
 

--- a/java-sdk/connectors/build.gradle
+++ b/java-sdk/connectors/build.gradle
@@ -11,6 +11,7 @@ subprojects {
   configurations {
     provided
     compile.extendsFrom(provided)
+    remoteConnector
   }
 
   repositories {
@@ -19,12 +20,30 @@ subprojects {
     maven {
       url "https://artifactory.lucidworks.com/artifactory/public-artifacts/"
     }
+
+    repositories {
+      def pluginsLucidworks =  ivy {
+        url 'https://plugins.lucidworks.com/'
+
+        patternLayout {
+          artifact '/[organisation]/5.3/[module]-[revision].[ext]'
+          artifact '/[organisation]/5.4/[module]-[revision].[ext]'
+        }
+
+        metadataSources { artifact() }
+      }
+      exclusiveContent {
+        forRepositories(pluginsLucidworks)
+        filter { includeGroup("remote-connector") }
+      }
+    }
   }
 
   dependencies {
     provided("com.lucidworks-connector.sdk:connector-plugin-sdk:${connectorsSDKVersion}")
     provided "org.slf4j:slf4j-api:${slf4jVersion}"
-    testCompile group: 'junit', name: 'junit', version: '4.12'
+    testCompile 'junit:junit:4.12'
+    remoteConnector "remote-connector:connector-plugin-standalone:${fusionVersion}"
   }
 }
 
@@ -79,24 +98,16 @@ configure(connectorprojects) { p ->
     }
   }
 
-  task connect(type: Exec, dependsOn: ["assemblePlugin"]) {
-    def clientJar = "${clientJarAbsolutePath}"
-    def argsList = []
-    argsList << "java"
-    argsList << "-Dcom.lucidworks.fusion.plugin.hosts=${fusionRpcTarget}"
-    argsList << "-Dcom.lucidworks.fusion.plugin.stop.port=${stopPort}"
-    if (project.hasProperty("debug")) {
-      argsList << "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5010"
-    }
-    argsList << "-jar"
-    argsList << clientJar
-    argsList << "${project.buildDir}/libs/${project.name}.zip"
-
-    commandLine argsList
-
+  task connect(type: JavaExec, dependsOn: assemblePlugin) {
+    main = 'com.lucidworks.connectors.ConnectorPluginStandaloneApp'
+    classpath = configurations.remoteConnector
+    File configYamlFile = file("${configYamlPath}")
+    String zipFile = "" + project.buildDir + "/libs/" + project.name + ".zip"
+    jvmArgs "-Dplugin.path=${zipFile}"
+    args configYamlFile.path
     doFirst {
-      println "   -- Using client-jar ${clientJar}"
-      println "   -- Connecting plugin ${project.buildDir}/libs/${project.name}.zip to ${fusionRpcTarget}"
+      println " >> Using plugin zip from: ${zipFile}"
+      println " >> Using the config file from: ${configYamlFile.path}"
     }
   }
 }

--- a/java-sdk/connectors/gradle.properties
+++ b/java-sdk/connectors/gradle.properties
@@ -11,8 +11,8 @@ userPass=admin:a-very-secret-password
 restService=http://127.0.0.1:6764/connectors
 maxTimeout=150
 # Connect tasks
-stopPort=55051
-fusionRpcTarget=localhost:8771
-clientJarAbsolutePath=/path/to/fusion/installation
+# see available versions of the remote connector jar in https://plugins.lucidworks.com/
+fusionVersion=5.3.3
+configYamlPath=/path/to/config.yaml
 # Other versions
 slf4jVersion=1.7.30


### PR DESCRIPTION
APOLLO-29034: connect task

## Connect to Fusion Remotely

Before trying to run plugins remotely, please go to [lucidworks](https://doc.lucidworks.com) to check how to configure fusion to run plugins remotely.

A configuration file `config.yaml` holding the cluster information is needed in order to connect remotely to a fusion cluster.

```bash
pulsar:
  service-url: <Pulsar Service URL>
  admin-url: <Pulsar Admin URL>
  tenant-name: <Pulsar Tenant Name (kube namespace)>
  authenticationEnabled: <Pulsar authentication enabled flag>
  tlsEnabled: <TLS enabled flag>
proxy:
  user: <Fusion proxy user>
  password: <Fusion proxy password>
  url: <Fusion proxy url>
```
NOTE: The `plugin.path` is not needed since the gradle task injects the plugin zip.

The steps to use the `connect` tasks are the following:
1. Create a `config.yaml` with your cluster information.
2. Verify that the fusionVersion is correct on the gradle.properties file.
3. Execute the `connect` task providing the plugin name and, the path to the configuration file.
```bash
./gradlew -p simple-connector connect -PconfigYamlPath=/path/to/config.yaml
```
4. After connecting to the cluster you should be able to see the plugin in Fusion's UI.