### PR TITLE
Remove a redundant throwing of an exception

### DIFF
--- a/java-sdk/connectors/incremental-connector/src/main/java/com/lucidworks/connector/plugins/incremental/fetcher/IncrementalContentFetcher.java
+++ b/java-sdk/connectors/incremental-connector/src/main/java/com/lucidworks/connector/plugins/incremental/fetcher/IncrementalContentFetcher.java
@@ -86,7 +86,7 @@ public class IncrementalContentFetcher implements ContentFetcher {
           fetchContext.newError(input.getId(), "Expected exception")
               .emit();
         }
-        throw npe;
+        
       }
     }
     return fetchContext.newResult();

--- a/java-sdk/connectors/incremental-connector/src/main/java/com/lucidworks/connector/plugins/incremental/fetcher/IncrementalContentFetcher.java
+++ b/java-sdk/connectors/incremental-connector/src/main/java/com/lucidworks/connector/plugins/incremental/fetcher/IncrementalContentFetcher.java
@@ -85,8 +85,9 @@ public class IncrementalContentFetcher implements ContentFetcher {
           logger.error("The following error is expected, as means to demonstrate how errors are emitted");
           fetchContext.newError(input.getId(), "Expected exception")
               .emit();
+          return fetchContext.newResult();
         }
-        
+        throw npe;
       }
     }
     return fetchContext.newResult();


### PR DESCRIPTION
The fetch call should not throw the exception - the emission of an error is the correct way to tell the backend about the fetch failure.

This issue caused the incremental-connector to not finish successfully because of a missing fetch response. That caused pytest test_demo_incremental.py to fail.