### PR TITLE
FUS-1533: Bump to connectors-sdk version 4.1.3

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -31,6 +31,7 @@ upload the exact same artifact (a zip file) into Fusion, so Fusion can host it f
 
 |====================================================
 | Fusion release | SDK version
+| 5.6.0 | link:https://github.com/lucidworks/connectors-sdk-resources/tree/v4.1.3[4.1.3]
 | 5.5.1 - 5.5.2 | link:https://github.com/lucidworks/connectors-sdk-resources/tree/v4.1.2[4.1.2]
 | 5.5.0 | link:https://github.com/lucidworks/connectors-sdk-resources/tree/v4.1.1[4.1.1]
 | 5.4.4 - 5.4.5 | link:https://github.com/lucidworks/connectors-sdk-resources/tree/v4.1.0[4.1.0]

--- a/java-sdk/connectors/gradle.properties
+++ b/java-sdk/connectors/gradle.properties
@@ -1,18 +1,18 @@
 # packaging properties
 group=com.lucidworks.connector.plugins
-version=2.1.0
+version=2.1.1
 #
 sourceCompatibility=11
 targetCompatibility=11
 #
-connectorsSDKVersion=4.1.0
+connectorsSDKVersion=4.1.3
 # Deploy tasks
 userPass=admin:a-very-secret-password
 restService=http://127.0.0.1:6764/connectors
 maxTimeout=150
 # Connect tasks
 # see available versions of the remote connector jar in https://plugins.lucidworks.com/
-fusionVersion=5.4.4
+fusionVersion=5.6.0
 configYamlPath=/path/to/config.yaml
 # Other versions
 slf4jVersion=1.7.30


### PR DESCRIPTION
Updating the version of the connectors sdk to 4.1.3 and Fusion version default to 5.6.0.