### PR TITLE
CONS-199 update to connector sdk for test connector and fusion sdk version

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -39,6 +39,7 @@ upload the exact same artifact (a zip file) into Fusion, so Fusion can host it f
 | Fusion release | SDK version
 | 5.11.x - 5.12.x | link:https://github.com/lucidworks/connectors-sdk-resources/tree/v4.2.1[4.2.1]
 | 5.10.x| link:https://github.com/lucidworks/connectors-sdk-resources/tree/v4.2.0[4.2.0]
+| 5.9.16 - 5.9.x| link:https://github.com/lucidworks/connectors-sdk-resources/tree/v4.2.1[4.2.2]
 | 5.9.11 - 5.9.x| link:https://github.com/lucidworks/connectors-sdk-resources/tree/v4.2.1[4.2.1]
 | 5.9.0 - 5.9.10| link:https://github.com/lucidworks/connectors-sdk-resources/tree/v4.2.0[4.2.0]
 | 5.8.0 - 5.8.x| link:https://github.com/lucidworks/connectors-sdk-resources/tree/v4.1.4[4.1.4]

--- a/java-sdk/connectors/gradle.properties
+++ b/java-sdk/connectors/gradle.properties
@@ -5,7 +5,7 @@ version=2.1.5
 sourceCompatibility=11
 targetCompatibility=11
 #
-connectorsSDKVersion=4.2.1
+connectorsSDKVersion=4.2.2
 # Deploy tasks
 userPass=admin:a-very-secret-password
 restService=http://127.0.0.1:6764/connectors


### PR DESCRIPTION
Update connector SDK version to 4.2.2 and add support matrix entry for Fusion
  5.9.16+

  Changes

  - Updated connectorsSDKVersion from 4.2.1 to 4.2.2 in
  java-sdk/connectors/gradle.properties
  - Added new support matrix entry for Fusion 5.9.16 - 5.9.x mapping to
  connector SDK v4.2.2 in README.asciidoc