### PR TITLE
Add lucidworks/platforms as code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @lucidworks/platforms


### PR DESCRIPTION
Adds/updates .github/CODEOWNERS so lucidworks/platforms is the code owner for this repo.